### PR TITLE
Reorder TextEmbeddingBaseModel arguments

### DIFF
--- a/src/lib/models/base/text-embedding.ts
+++ b/src/lib/models/base/text-embedding.ts
@@ -4,7 +4,7 @@ import { EmbeddingsResponse } from '@/lib/types/embeddings/response';
 
 export abstract class TextEmbeddingBaseModel extends BaseModel {
 
-  protected constructor(authToken: string, protected endpoint: string) {
+  protected constructor(protected endpoint: string, authToken: string) {
     super(endpoint, authToken);
   }
 

--- a/src/lib/models/embeddings/bge-base-en-v15.ts
+++ b/src/lib/models/embeddings/bge-base-en-v15.ts
@@ -3,6 +3,6 @@ import {TextEmbeddingBaseModel} from '@/lib/models/base/text-embedding';
 export class BgeBaseEnV15 extends TextEmbeddingBaseModel {
   static endpoint: string = 'https://api.deepinfra.com/v1/inference/BAAI/bge-base-en-v1.5';
   constructor(authToken: string) {
-    super(authToken, BgeBaseEnV15.endpoint);
+    super(BgeBaseEnV15.endpoint, authToken);
   }
 }

--- a/src/lib/models/embeddings/bge-large-en-v15.ts
+++ b/src/lib/models/embeddings/bge-large-en-v15.ts
@@ -3,6 +3,6 @@ import {TextEmbeddingBaseModel} from '@/lib/models/base/text-embedding';
 export class BgeLargeEnV15 extends TextEmbeddingBaseModel {
   static endpoint: string = 'https://api.deepinfra.com/v1/inference/BAAI/bge-large-en-v1.5';
   constructor(authToken: string) {
-    super(authToken, BgeLargeEnV15.endpoint);
+    super(BgeLargeEnV15.endpoint, authToken);
   }
 }

--- a/src/lib/models/embeddings/gte-base.ts
+++ b/src/lib/models/embeddings/gte-base.ts
@@ -4,6 +4,6 @@ export class GteBase extends TextEmbeddingBaseModel {
   public static endpoint: string = 'https://api.deepinfra.com/v1/inference/thenlper/gte-base';
 
   constructor(authToken: string) {
-    super(authToken, GteBase.endpoint);
+    super(GteBase.endpoint, authToken);
   }
 }

--- a/src/lib/models/embeddings/gte-large.ts
+++ b/src/lib/models/embeddings/gte-large.ts
@@ -5,6 +5,6 @@ export class GteLarge extends TextEmbeddingBaseModel {
   public static endpoint: string = 'https://api.deepinfra.com/v1/inference/thenlper/gte-large';
 
   constructor(authToken: string) {
-    super(authToken, GteLarge.endpoint);
+    super(GteLarge.endpoint, authToken);
   }
 }


### PR DESCRIPTION
All other base models accept endpoint first, then authToken.