### PR TITLE
Cog models + SDXL

### DIFF
--- a/src/lib/models/base/cog-model.ts
+++ b/src/lib/models/base/cog-model.ts
@@ -1,0 +1,39 @@
+import { AxiosError } from 'axios';
+import { BaseModel } from '@/lib/models/base';
+import {CogResponse} from '@/lib/types/cog/response';
+import {CogRequest} from '@/lib/types/cog/request';
+
+export class CogBaseModel<CogIn, CogOut> extends BaseModel {
+
+  constructor(protected endpoint: string, authToken: string) {
+    super(endpoint, authToken);
+  }
+
+  public async generate(
+    body: CogRequest<CogIn>,
+  ): Promise<CogResponse<CogIn, CogOut>> {
+    try {
+      const response = await this.client.post<CogResponse<CogIn, CogOut>>(body);
+      return response.data;
+    } catch (error) {
+      this.handleError(error);
+      throw new Error('Failed to generate text');
+    }
+  }
+
+  private handleError(error: unknown) {
+    if (error instanceof AxiosError) {
+      if (error.response) {
+        console.error('Response data:', error.response.data);
+        console.error('Status:', error.response.status);
+        console.error('Headers:', error.response.headers);
+      } else if (error.request) {
+        console.error('No response received:', error.request);
+      } else {
+        console.error('Error message:', error.message);
+      }
+    } else {
+      console.error('An unexpected error occurred:', error);
+    }
+  }
+}

--- a/src/lib/models/text-to-image/sdxl.ts
+++ b/src/lib/models/text-to-image/sdxl.ts
@@ -1,26 +1,10 @@
-import {TextToImageBaseModel} from '@/lib/models/base';
-import {TextToImageResponse} from '@/lib/types/text-to-image/response';
-import {TextToImageRequest} from '@/lib/types/text-to-image/request';
-import {AxiosResponse} from 'axios';
+import {CogBaseModel} from '@/lib/models/base/cog-model';
+import {SdxlIn} from '@/lib/types/cog/sdxl/request';
+import {SdxlOut} from '@/lib/types/cog/sdxl/response';
 
-
-export class Sdxl extends TextToImageBaseModel {
+export class Sdxl extends CogBaseModel<SdxlIn, SdxlOut> {
   public static readonly endpoint: string = 'https://api.deepinfra.com/v1/inference/stability-ai/sdxl';
   constructor(authToken: string) {
     super(Sdxl.endpoint, authToken);
-  }
-
-  public async generate(input: TextToImageRequest): Promise<TextToImageResponse> {
-    const body = {
-      input
-    };
-
-    try {
-      const response: AxiosResponse<TextToImageResponse> = await this.client.post<TextToImageResponse>(body);
-      return response.data;
-    } catch (error) {
-      console.error('Error generating image:', error);
-      throw error;
-    }
   }
 }

--- a/src/lib/types/cog/request.ts
+++ b/src/lib/types/cog/request.ts
@@ -1,0 +1,10 @@
+export type WebhookEventType = 'start' | 'output' | 'logs' | 'completed';
+
+export interface CogRequest<Req> {
+  id?: string;
+  version?: string | null;
+  input: Req;
+  webhook?: string | null;
+  webhook_events_filter?: WebhookEventType[];
+}
+

--- a/src/lib/types/cog/response.ts
+++ b/src/lib/types/cog/response.ts
@@ -1,0 +1,22 @@
+import {CogRequest} from './request';
+
+export type CogStatus = 'succeeded' | 'failed';
+export interface CogResponse<Req, Res> extends CogRequest<Req> {
+  status: CogStatus;
+  created_at: string | null;
+  started_at: string;
+  complated_at: string;
+  output: Res;
+  error: string | null;
+  logs: string;
+  inference_status: {
+    status: CogStatus,
+    runtime_ms: number,
+    cost: number,
+    tokens_generated: number | null,
+    tokens_input: number | null,
+  },
+  metrics: {
+    predict_time: number;
+  };
+}

--- a/src/lib/types/cog/sdxl/request.ts
+++ b/src/lib/types/cog/sdxl/request.ts
@@ -1,0 +1,18 @@
+export interface SdxlIn {
+  prompt: string;
+  negative_prompt?: string;
+  image?: string; // ? base64
+  mask?: string; // ? base64
+  width?: number;
+  height?: number;
+  num_outputs?: number;
+  scheduler?: 'DDIM' | 'DPMSolverMultistep' | 'HeunDiscrete' | 'KarrasDPM' | 'K_EULER_ANCESTRAL' | 'K_EULER' | 'PNDM';
+  num_inference_steps?: number;
+  guidance_scale?: number;
+  prompt_strength?: number;
+  seed?: number;
+  refine?: 'no_refiner' | 'expert_ensemble_refiner' | 'base_image_refiner';
+  high_noise_frac?: number;
+  refine_steps?: number;
+  apply_watermark?: boolean;
+}

--- a/src/lib/types/cog/sdxl/response.ts
+++ b/src/lib/types/cog/sdxl/response.ts
@@ -1,0 +1,1 @@
+export type SdxlOut = string[];


### PR DESCRIPTION
DeepInfra supports 2 types of custom models:
- COG based (old)
- LLM custom models

COG-based ones, have a specific interface -- i.e each model, even each revision, can have it's own interface. Also the input/output json follows a particular schema (so there is a model specific bit, but also common bits outside). Encode this in `CogBaseModel`, and the common bits in `CogRequest`, `CogResponse`, so people can even query their own custom COGs by specifying the model-specific bits.

LLM custom models have the same interface as other text-generation models.

Also implement `SDXL` as a `CogBaseModel`. I think the cog models should live in their own directory (not in `text-to-image` as it's now), but that is a minor correction.

I'm a bit new to typescript, so I might have messed something up.

I'll fix the TextToImage type in another patch, the current one assumes all SDXL params are available to all TextToImage models, but that is not the case.