### PR TITLE
bugfix(text-to-image types): TextToImage fields differ from SDXL fields

### DIFF
--- a/src/lib/types/text-to-image/request.ts
+++ b/src/lib/types/text-to-image/request.ts
@@ -2,17 +2,13 @@ export interface TextToImageRequest {
   prompt: string;
   negative_prompt?: string;
   image?: string;
-  mask?: string;
-  width?: number;
-  height?: number;
-  num_outputs?: number;
-  scheduler?: 'DDIM' | 'DPMSolverMultistep' | 'HeunDiscrete' | 'KarrasDPM' | 'K_EULER_ANCESTRAL' | 'K_EULER' | 'PNDM';
+  num_images?: number;
   num_inference_steps?: number;
   guidance_scale?: number;
-  prompt_strength?: number;
+  strength?: number;
+  width?: 128 | 256 | 384 | 448 | 512 | 576 | 640 | 704 | 768 | 832 | 896 | 960 | 1024;
+  height?: 128 | 256 | 384 | 448 | 512 | 576 | 640 | 704 | 768 | 832 | 896 | 960 | 1024;
   seed?: number;
-  refine?: 'no_refiner' | 'expert_ensemble_refiner' | 'base_image_refiner';
-  high_noise_frac?: number;
-  refine_steps?: number;
-  apply_watermark?: boolean;
+  use_compel?: boolean;
+  webhook?: string;
 }

--- a/src/lib/types/text-to-image/response.ts
+++ b/src/lib/types/text-to-image/response.ts
@@ -1,23 +1,10 @@
-import {TextToImageRequest} from '@/lib/types/text-to-image/request';
 import {Status} from '@/lib/types/common/status';
 
 export interface TextToImageResponse {
+  images: string[];
+  nsfw_content_detected: boolean[];
+  seed: number;
+
   request_id: string;
   inference_status: Status;
-  input: TextToImageRequest;
-  output: string[];
-  id: string;
-  version: string | null;
-  created_at: string | null;
-  started_at: string;
-  completed_at: string;
-  logs: string;
-  error: string | null;
-  status: 'succeeded';
-  metrics: {
-    predict_time: number;
-  };
-  webhook: string | null;
-  webhook_events_filter: string[];
-  output_file_prefix: string;
 }


### PR DESCRIPTION
The interface for text-to-image models is the same across all models except cog-based models (like SDXL). The API/interface is: defined here https://deepinfra.com/runwayml/stable-diffusion-v1-5/api.